### PR TITLE
Move mentoring notes workspace outside slide card

### DIFF
--- a/mentoring.html
+++ b/mentoring.html
@@ -75,7 +75,7 @@
             --dur-3: 320ms;
 
             --target-min: 44px;
-            --container-max: 900px;
+            --container-max: 1080px;
         }
 
         /* ------------------------------- Global reset / mobile stability ----------------------------------*/
@@ -99,9 +99,14 @@
 
         /* ------------------------------- App shell ----------------------------------*/
         #app-wrapper {
-            display: flex; justify-content: center; align-items: flex-start;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: var(--space-6);
             padding: max(var(--space-7), env(safe-area-inset-top)) var(--space-4) var(--space-7);
-            width: 100%; min-height: 100dvh;
+            width: 100%;
+            min-height: 100dvh;
             background: radial-gradient(800px 600px at 20% 0%, rgba(156,175,136,0.08) 0%, transparent 70%),
                         radial-gradient(700px 500px at 80% 100%, rgba(90,107,82,0.06) 0%, transparent 65%);
         }
@@ -443,6 +448,16 @@
             font-size: var(--step--1);
             color: var(--ink-muted);
         }
+        .slide-notes-rail {
+            display: flex;
+            flex-direction: column;
+            gap: var(--space-4);
+            background: color-mix(in srgb, var(--soft-white) 96%, white 4%);
+            border: 1px solid rgba(122, 132, 113, 0.14);
+            border-radius: var(--radius-lg);
+            padding: var(--space-4);
+            box-shadow: var(--shadow-1);
+        }
         .textbox-toolbar {
             margin-top: var(--space-6);
             margin-bottom: var(--space-3);
@@ -467,9 +482,16 @@
             background: #fff;
             font-family: var(--font-body);
         }
+        .slide-notes-rail .textbox-toolbar {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
         .textbox-collection {
             display: grid;
             gap: var(--space-3);
+        }
+        .slide-notes-rail .textbox-collection {
+            min-width: 0;
         }
         .custom-textbox {
             position: relative;
@@ -534,6 +556,35 @@
                 justify-content: center;
             }
         }
+        #slide-notes-dock {
+            width: min(360px, 90%);
+            display: flex;
+            flex-direction: column;
+            gap: var(--space-4);
+            flex: 0 0 auto;
+            margin-inline: auto;
+        }
+        #slide-notes-workspace {
+            display: flex;
+            flex-direction: column;
+            gap: var(--space-4);
+        }
+        #slide-notes-dock .slide-notes-rail {
+            flex: 1 1 auto;
+        }
+        @media (min-width: 992px) {
+            #app-wrapper {
+                flex-direction: row;
+                align-items: flex-start;
+            }
+            #slide-notes-dock {
+                position: sticky;
+                top: clamp(2rem, 4vw, 3.5rem);
+                max-height: calc(100vh - clamp(2rem, 4vw, 3.5rem));
+                overflow: auto;
+                width: clamp(300px, 24vw, 360px);
+            }
+        }
         .animate-on-scroll {
             opacity: 0;
         }
@@ -543,17 +594,6 @@
 
     <div id="app-wrapper">
         <div id="activity-container">
-
-            <div id="notes-io-controls" class="animate-on-scroll">
-                <h2><i class="fas fa-note-sticky"></i> Slide Text Boxes</h2>
-                <div class="notes-io-actions">
-                    <button type="button" class="activity-btn secondary" id="save-notes-btn"><i class="fas fa-file-arrow-down"></i> Save Notes (JSON)</button>
-                    <button type="button" class="activity-btn secondary" id="load-notes-btn"><i class="fas fa-file-arrow-up"></i> Load Notes (JSON)</button>
-                    <input type="file" id="notes-file-input" accept="application/json" hidden>
-                </div>
-                <p class="notes-io-hint">Add rounded notes to each slide, choose a light background, and save or reload your work when you're finished.</p>
-            </div>
-
             <!-- Slide 1: Title Slide -->
             <div id="slide-1" class="screen active">
                 <div class="animate-on-scroll">
@@ -1155,6 +1195,18 @@
             </div>
 
         </div>
+        <aside id="slide-notes-dock" aria-label="Slide text boxes workspace">
+            <div id="notes-io-controls">
+                <h2><i class="fas fa-note-sticky"></i> Slide Text Boxes</h2>
+                <div class="notes-io-actions">
+                    <button type="button" class="activity-btn secondary" id="save-notes-btn"><i class="fas fa-file-arrow-down"></i> Save Notes (JSON)</button>
+                    <button type="button" class="activity-btn secondary" id="load-notes-btn"><i class="fas fa-file-arrow-up"></i> Load Notes (JSON)</button>
+                    <input type="file" id="notes-file-input" accept="application/json" hidden>
+                </div>
+                <p class="notes-io-hint">Manage collaborative notes for each slide here, and save or reload your work when you're finished.</p>
+            </div>
+            <div id="slide-notes-workspace" aria-live="polite"></div>
+        </aside>
     </div>
 
     <script>
@@ -1168,9 +1220,10 @@
         ];
 
         let currentSlideIndex = 0;
-        const slides = document.querySelectorAll('.screen');
+        const slides = Array.from(document.querySelectorAll('.screen'));
         let slideNotes = {};
         const textboxContainers = {};
+        const notesPanels = {};
 
         function generateNoteId() {
             return `note-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
@@ -1247,12 +1300,36 @@
         }
 
         function renderAllSlides() {
+            if (!slides.length) {
+                setupNotesIoControls();
+                return;
+            }
+
             slides.forEach((slide, index) => {
                 const slideId = slide.dataset.slideId || slide.id || `slide-${index + 1}`;
                 if (!Array.isArray(slideNotes[slideId])) {
                     slideNotes[slideId] = [];
                 }
                 renderSlideTextboxes(slideId);
+            });
+
+            updateNotesDock(currentSlideIndex);
+        }
+
+        function updateNotesDock(index) {
+            const workspace = document.getElementById('slide-notes-workspace');
+            const slide = slides[index];
+            if (!workspace || !slide) {
+                return;
+            }
+
+            const slideId = slide.dataset.slideId || slide.id || `slide-${index + 1}`;
+
+            Object.entries(notesPanels).forEach(([id, panel]) => {
+                if (!panel) {
+                    return;
+                }
+                panel.hidden = id !== slideId;
             });
         }
 
@@ -1349,6 +1426,9 @@
                             alert('Unable to read that JSON file. Please check the format and try again.');
                         }
                     };
+                    reader.onerror = () => {
+                        alert('We could not read that file. Please try again with a different JSON export.');
+                    };
                     reader.readAsText(file);
                     event.target.value = '';
                 });
@@ -1356,15 +1436,23 @@
         }
 
         function initializeTextboxes() {
+            const workspace = document.getElementById('slide-notes-workspace');
             slideNotes = loadStoredNotes();
+
+            if (!workspace) {
+                setupNotesIoControls();
+                return;
+            }
+
+            workspace.innerHTML = '';
+            Object.keys(notesPanels).forEach(key => delete notesPanels[key]);
+
             slides.forEach((slide, index) => {
                 const slideId = slide.id || `slide-${index + 1}`;
                 slide.dataset.slideId = slideId;
                 if (!Array.isArray(slideNotes[slideId])) {
                     slideNotes[slideId] = [];
                 }
-
-                const controlsAnchor = slide.querySelector('.controls');
 
                 const toolbar = document.createElement('div');
                 toolbar.className = 'textbox-toolbar';
@@ -1395,21 +1483,28 @@
                 collection.className = 'textbox-collection';
                 textboxContainers[slideId] = collection;
 
-                if (controlsAnchor) {
-                    slide.insertBefore(toolbar, controlsAnchor);
-                    slide.insertBefore(collection, controlsAnchor);
-                } else {
-                    slide.appendChild(toolbar);
-                    slide.appendChild(collection);
-                }
+                const notesPanel = document.createElement('section');
+                notesPanel.className = 'slide-notes-rail';
+                notesPanel.setAttribute('aria-label', 'Slide text boxes');
+                notesPanel.dataset.slideId = slideId;
+                notesPanel.appendChild(toolbar);
+                notesPanel.appendChild(collection);
+                notesPanel.hidden = index !== currentSlideIndex;
+
+                workspace.appendChild(notesPanel);
+                notesPanels[slideId] = notesPanel;
 
                 renderSlideTextboxes(slideId);
             });
 
             setupNotesIoControls();
+            updateNotesDock(currentSlideIndex);
         }
 
         function showSlide(index) {
+            if (!Number.isInteger(index) || index < 0 || index >= slides.length) {
+                return;
+            }
             slides.forEach((slide, i) => {
                 slide.classList.remove('active');
                 if (i === index) {
@@ -1425,6 +1520,7 @@
                 }
             });
             currentSlideIndex = index;
+            updateNotesDock(index);
         }
 
         function nextSlide() {
@@ -1464,6 +1560,12 @@
         document.addEventListener('DOMContentLoaded', () => {
             initializeTextboxes();
             showSlide(0);
+
+            const notesPanel = document.getElementById('notes-io-controls');
+            if (notesPanel) {
+                notesPanel.classList.add('animate__animated', 'animate__fadeInDown');
+                notesPanel.style.opacity = '1';
+            }
         });
     </script>
 


### PR DESCRIPTION
## Summary
- relocate the slide text box controls into a dedicated notes dock beside the mentoring deck
- keep only one notes panel visible at a time while widening the main activity card
- update the notes renderer to target the new workspace and preserve save/load behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9e5c476d8832699489ca97c00596b